### PR TITLE
Fix README in MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,4 @@
-README.txt
+README.md
 setup.py
 LICENSE
 src/__init__.py


### PR DESCRIPTION
A tiny change to the MANIFEST that will fix an error message from `pip`.