### PR TITLE
remove unused numpy import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ***********************************************************************************
-# * Copyright 2010-2019 Paulo A. Herrera. All rights reserved.                           * 
+# * Copyright 2010-2019 Paulo A. Herrera. All rights reserved.                           *
 # *                                                                                 *
 # * Redistribution and use in source and binary forms, with or without              *
 # * modification, are permitted provided that the following conditions are met:     *
@@ -29,7 +29,6 @@
 #except ImportError:
 from distutils.core import setup
 
-import numpy as np
 from src.version import PYEVTK_VERSION
 
 def readme(fname):


### PR DESCRIPTION
Maybe, we should also consider using _setuptool.setup_ to include the _install_requires_ option,

see for example
https://stackoverflow.com/questions/17727398/how-to-specify-dependencies-when-creating-the-setup-py-file-for-a-python-package

