### PR TITLE
define installation requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@
 #    from setuptools import setup
 #except ImportError:
 from distutils.core import setup
-
-import numpy as np
 from src.version import PYEVTK_VERSION
 
 def readme(fname):
@@ -47,6 +45,10 @@ setup(
     packages = ['evtk'],
     package_dir = {'evtk' : 'src'},
     package_data = {'evtk' :  ['LICENSE', 'examples/*.py']},
+    install_requires = [
+        "numpy>=1.8",
+        "scipy>=1.2"
+    ],
     project_urls={
         "Bug Tracker": "https://github.com/paulo-herrera/PyEVTK",
         "Documentation": "https://github.com/paulo-herrera/PyEVTK",


### PR DESCRIPTION
Hi @paulo-herrera ,

I noticed the installation of the package fails, when following the install instructions but not having the requirements already installed. This change was already proposed in #3 . I consider this a necessity.

The change proposed in this MR makes sure that this package can be properly installed without making assumptions about the pre-existing state of the environment.