### PR TITLE
Allow install into conda env with GitHub and pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,19 +22,15 @@
 # SOFTWARE.
 ######################################################################################
 
-import setuptools                          # needed to create wheel file
-from distutils.core import setup
-from evtk.version import PYEVTK_VERSION
+from setuptools import setup
 
-def readme(fname):
-    with open(fname, 'r') as f:
-        return f.read()
+exec(open("evtk/version.py").read())
 
 setup(
     name = 'evtk',
-    version = PYEVTK_VERSION,
+    version = __version__,
     description = 'Exports data as binary VTK files',
-    long_description = readme('README.md'),
+    long_description = open("README.md").read(),
     author = 'Paulo Herrera',
     author_email = 'paulo.herrera.eirl@gmail.com',
     url = 'https://github.com/paulo-herrera/PyEVTK.git',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ exec(open("evtk/version.py").read())
 
 setup(
     name = 'evtk',
-    version = __version__,
+    version = PYEVTK_VERSION,
     description = 'Exports data as binary VTK files',
     long_description = open("README.md").read(),
     author = 'Paulo Herrera',


### PR DESCRIPTION
I wanted to be able to install PyEVTK from GitHub into a conda environment through pip in a conda `environment.yml`. This was not possible because of the way the version number was being imported. So these changes now permit a conda `environment.yml` to look like, e.g.
```
name: my-env
dependencies:
- python>3.6
- jupyter
- matplotlib
- numpy
- pip
- scipy

- pip:
  - git+https://github.com/paulo-herrera/PyEVTK.git
 ```